### PR TITLE
PL-1233 Added input filters for structure filtering

### DIFF
--- a/buildSrc/src/main/java/tasks/DrawModulesStructureTask.kt
+++ b/buildSrc/src/main/java/tasks/DrawModulesStructureTask.kt
@@ -34,7 +34,7 @@ open class DrawModulesStructureTask : DefaultTask() {
             nodesList
         } else {
             nodesList.filter { node ->
-                filtersInput.any { filter -> node.name == filter }
+                filtersInput.any { filter -> node.name.contains(filter) }
             }
         }
 


### PR DESCRIPTION
To run the plugin, you need to call the command:

`./gradlew drawModules`

In this case, the plugin will output (for now to the console) the structure of module connections.

If you need to filter the returned result, you can add the filters parameter:
`./gradlew drawModules --filters=filterName` - for one filter
`./gradlew drawModules --filters={filterName1,filterName2,...}` - for filter list

In this case, the plugin will display the structure of only those modules that match the specified filters (module names must "include" filters).

Example 1: we want to get a structure for cargo modules only:
`./gradlew drawModules --filters=cargo`

Example 2: we want to get a structure only for the cargo and superservice modules:
`./gradlew drawModules --filters={cargo,superservice}`