### PR TITLE
PL-1385: search for root module

### DIFF
--- a/buildSrc/src/main/java/extensions/GraphExtensions.kt
+++ b/buildSrc/src/main/java/extensions/GraphExtensions.kt
@@ -76,7 +76,7 @@ fun Graph.findMostDistantNodes(rootNodeName: String): MostDistantNodesResult {
 }
 
 
-fun Graph.findRootNode(): Set<GraphNode> {
+fun Graph.findRootNodeCandidates(): Set<GraphNode> {
     if (nodes.isEmpty()) {
         return emptySet()
     }

--- a/buildSrc/src/main/java/tasks/DrawModulesStructureTask.kt
+++ b/buildSrc/src/main/java/tasks/DrawModulesStructureTask.kt
@@ -1,7 +1,7 @@
 package tasks
 
 import extensions.findLongestPaths
-import extensions.findRootNode
+import extensions.findRootNodeCandidates
 import extensions.getParentToChildrenStructure
 import models.Graph
 import models.GraphNode
@@ -42,7 +42,7 @@ open class DrawModulesStructureTask : DefaultTask() {
         val filteredNodes = filterNodesIfNeeded(graph.nodes)
         printModulesStructure(filteredNodes)
 
-        val rootNode = getRootNodes(graph)
+        val rootNode = getRootNode(graph)
         val longestPaths = if (rootNode != null) {
             val foundLongestPaths = findLongestPaths(graph, rootNode)
             printLongestPaths(foundLongestPaths, rootNode)
@@ -55,12 +55,12 @@ open class DrawModulesStructureTask : DefaultTask() {
         GraphVizUtil.generateGraphImage(filteredGraph, longestPaths)
     }
 
-    private fun getRootNodes(graph: Graph): String? {
+    private fun getRootNode(graph: Graph): String? {
         if (rootModule.isNotEmpty()) {
             return rootModule
         }
 
-        val rootNodes = graph.findRootNode()
+        val rootNodes = graph.findRootNodeCandidates()
         return when {
             rootNodes.isEmpty() -> {
                 println("The project doesn't has a root module")


### PR DESCRIPTION
[Ticket](https://indriver.atlassian.net/browse/PL-1385)

If a user passes "rootModule" parameter in cli, the plugin uses it to find longest paths. Otherwise the plugin searches for root nodes on its own. If the plugin finds a few root nodes it suggests user to choose the one.